### PR TITLE
Update the golem-docker-dev command to directly readlink

### DIFF
--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -43,6 +43,13 @@ function golem-docker-dev() {
   make binary
   version=`cat VERSION`
   path_restore
-  golem-docker $version $@
+
+  binary=$(readlink -f "$GOPATH/src/github.com/docker/docker/bundles/$version/binary/docker")
+  if [ ! -f $binary ]; then
+    echo "Failed to get binary for $version"
+    return 1
+  fi
+
+  golem -db $binary $@
 }
 


### PR DESCRIPTION
Not every version is handled correctly in `golem-dev`, since the version and directory on known during the run on `golem-docker-dev`, do the readlink and call golem immediately.
