### PR TITLE
Set default docker version in run container

### DIFF
--- a/runner/configuration.go
+++ b/runner/configuration.go
@@ -144,7 +144,8 @@ type ConfigurationManager struct {
 // and registers associated flags.
 func NewConfigurationManager() *ConfigurationManager {
 	m := &ConfigurationManager{
-		flagResolver: newFlagResolver(),
+		flagResolver:  newFlagResolver(),
+		dockerVersion: configurationVersion(versionutil.StaticVersion(1, 10, 1)),
 	}
 
 	// TODO: support extra images


### PR DESCRIPTION
Currently if no `-dv` or `--docker-version` is given the container will fail to build since an empty `ENV DOCKER_VERSION` will try to be set. This ensures that the docker version is never empty when building the base image.