### PR TITLE
Use /dev/urandom to generate random images

### DIFF
--- a/examples/registry/helpers.bash
+++ b/examples/registry/helpers.bash
@@ -48,7 +48,7 @@ function has_digest() {
 # requires bats
 function tempImage() {
 	dir=$(mktemp -d)
-	run dd if=/dev/random of="$dir/f" bs=1024 count=512
+	run dd if=/dev/urandom of="$dir/f" bs=1024 count=512
 	cat <<DockerFileContent > "$dir/Dockerfile"
 FROM scratch
 COPY f /f


### PR DESCRIPTION
The existing code read a relatively large number of bytes from
/dev/random. Since /dev/random blocks until entropy is available, this
could hang on systems like VMs that don't have as many sources of
entropy. Using /dev/urandom is much more reliable.