### PR TITLE
Strip commit from name when using dev version

### DIFF
--- a/versionutil/version.go
+++ b/versionutil/version.go
@@ -75,6 +75,10 @@ func ParseVersion(s string) (v Version, err error) {
 	v.Tag = submatches[4]
 	v.Commit = submatches[5]
 
+	if v.Commit != "" {
+		v.Name = v.Name[0 : len(v.Name)-len(v.Commit)-1]
+	}
+
 	return
 }
 


### PR DESCRIPTION
Commit is always added when getting the string representation.
When parsing a version with the commit this causes the commit to get added twice.