### PR TITLE
Add version checks for OAuth

### DIFF
--- a/examples/registry/golem.conf
+++ b/examples/registry/golem.conf
@@ -1,6 +1,6 @@
 [[suite]]
   dind=true
-  images=[ "nginx:1.9", "golang:1.4", "hello-world:latest", "dmcgowan/token-server:simple" ]
+  images=[ "nginx:1.9", "golang:1.4", "hello-world:latest", "dmcgowan/token-server:simple", "dmcgowan/token-server:oauth" ]
 
   [[suite.pretest]]
     command="/bin/sh ./install_certs.sh localregistry"

--- a/examples/registry/token.bats
+++ b/examples/registry/token.bats
@@ -51,10 +51,14 @@ base="hello-world"
 }
 
 @test "Test oauth token server login" {
+	version_check docker "$DOCKER_VERSION" "1.11.0"
+
 	login_oauth localregistry:5557
 }
 
 @test "Test oauth token server bad login" {
+	version_check docker "$DOCKER_VERSION" "1.11.0"
+
 	run docker login -u "testuser" -p "badpassword" -e $email localregistry:5557
 	[ "$status" -ne 0 ]
 
@@ -63,6 +67,8 @@ base="hello-world"
 }
 
 @test "Test oauth push and pull with token auth" {
+	version_check docker "$DOCKER_VERSION" "1.11.0"
+
 	login_oauth localregistry:5558
 	image="localregistry:5558/testuser/token"
 	build $image "$base:latest"
@@ -78,6 +84,8 @@ base="hello-world"
 }
 
 @test "Test oauth push and pull with token auth wrong namespace" {
+	version_check docker "$DOCKER_VERSION" "1.11.0"
+
 	login_oauth localregistry:5558
 	image="localregistry:5558/notuser/token"
 	build $image "$base:latest"


### PR DESCRIPTION
Ensures tests will pass on 1.10 and before and pass with 1.11 and later