### PR TITLE
Fix V1 registry unreliable startup

### DIFF
--- a/examples/registry/docker-compose.yml
+++ b/examples/registry/docker-compose.yml
@@ -21,6 +21,8 @@ registryv1:
   image: golem-registry:latest
   ports:
     - "5000"
+  volumes:
+    - ./v1_registry_config.yml:/docker-registry/config/config_sample.yml
 registryv2:
   image: golem-distribution:latest
   ports:

--- a/examples/registry/v1_registry_config.yml
+++ b/examples/registry/v1_registry_config.yml
@@ -1,0 +1,227 @@
+# All other flavors inherit the `common' config snippet
+common: &common
+    issue: '"docker-registry server"'
+    # Default log level is info
+    loglevel: _env:LOGLEVEL:info
+    # Enable debugging (additional informations in the output of the _ping endpoint)
+    debug: _env:DEBUG:false
+    # By default, the registry acts standalone (eg: doesn't query the index)
+    standalone: _env:STANDALONE:true
+    # The default endpoint to use (if NOT standalone) is index.docker.io
+    index_endpoint: _env:INDEX_ENDPOINT:https://index.docker.io
+    # Storage redirect is disabled
+    storage_redirect: _env:STORAGE_REDIRECT
+    # Token auth is enabled (if NOT standalone)
+    disable_token_auth: _env:DISABLE_TOKEN_AUTH
+    # No priv key
+    privileged_key: _env:PRIVILEGED_KEY
+    # No search backend
+    search_backend: _env:SEARCH_BACKEND
+    # SQLite search backend
+    sqlalchemy_index_database: _env:SQLALCHEMY_INDEX_DATABASE:sqlite:////tmp/docker-registry.db
+
+    # Mirroring is not enabled
+    mirroring:
+        source: _env:MIRROR_SOURCE # https://registry-1.docker.io
+        source_index: _env:MIRROR_SOURCE_INDEX # https://index.docker.io
+        tags_cache_ttl: _env:MIRROR_TAGS_CACHE_TTL:172800 # seconds
+
+    cache:
+        host: _env:CACHE_REDIS_HOST
+        port: _env:CACHE_REDIS_PORT
+        db: _env:CACHE_REDIS_DB:0
+        password: _env:CACHE_REDIS_PASSWORD
+
+    # Enabling LRU cache for small files
+    # This speeds up read/write on small files
+    # when using a remote storage backend (like S3).
+    cache_lru:
+        host: _env:CACHE_LRU_REDIS_HOST
+        port: _env:CACHE_LRU_REDIS_PORT
+        db: _env:CACHE_LRU_REDIS_DB:0
+        password: _env:CACHE_LRU_REDIS_PASSWORD
+
+    # Enabling these options makes the Registry send an email on each code Exception
+    email_exceptions:
+        smtp_host: _env:SMTP_HOST
+        smtp_port: _env:SMTP_PORT:25
+        smtp_login: _env:SMTP_LOGIN
+        smtp_password: _env:SMTP_PASSWORD
+        smtp_secure: _env:SMTP_SECURE:false
+        from_addr: _env:SMTP_FROM_ADDR:docker-registry@localdomain.local
+        to_addr: _env:SMTP_TO_ADDR:noise+dockerregistry@localdomain.local
+
+    # Enable bugsnag (set the API key)
+    bugsnag: _env:BUGSNAG
+
+    # CORS support is not enabled by default
+    cors:
+        origins: _env:CORS_ORIGINS
+        methods: _env:CORS_METHODS
+        headers: _env:CORS_HEADERS:[Content-Type]
+        expose_headers: _env:CORS_EXPOSE_HEADERS
+        supports_credentials: _env:CORS_SUPPORTS_CREDENTIALS
+        max_age: _env:CORS_MAX_AGE
+        send_wildcard: _env:CORS_SEND_WILDCARD
+        always_send: _env:CORS_ALWAYS_SEND
+        automatic_options: _env:CORS_AUTOMATIC_OPTIONS
+        vary_header: _env:CORS_VARY_HEADER
+        resources: _env:CORS_RESOURCES
+
+local: &local
+    <<: *common
+    storage: local
+    storage_path: _env:STORAGE_PATH:/tmp/registry
+
+
+s3: &s3
+    <<: *common
+    storage: s3
+    s3_region: _env:AWS_REGION
+    s3_bucket: _env:AWS_BUCKET
+    boto_bucket: _env:AWS_BUCKET
+    storage_path: _env:STORAGE_PATH:/registry
+    s3_encrypt: _env:AWS_ENCRYPT:true
+    s3_secure: _env:AWS_SECURE:true
+    s3_access_key: _env:AWS_KEY
+    s3_secret_key: _env:AWS_SECRET
+    s3_use_sigv4: _env:AWS_USE_SIGV4
+    boto_host: _env:AWS_HOST
+    boto_port: _env:AWS_PORT
+    boto_calling_format: _env:AWS_CALLING_FORMAT
+
+cloudfronts3: &cloudfronts3
+    <<: *s3
+    cloudfront:
+        base: _env:CF_BASE_URL
+        keyid: _env:CF_KEYID
+        keysecret: _env:CF_KEYSECRET
+
+azureblob: &azureblob
+    <<: *common
+    storage: azureblob
+    azure_storage_account_name: _env:AZURE_STORAGE_ACCOUNT_NAME
+    azure_storage_account_key: _env:AZURE_STORAGE_ACCOUNT_KEY
+    azure_storage_container: _env:AZURE_STORAGE_CONTAINER:registry
+    azure_use_https: _env:AZURE_USE_HTTPS:true
+
+# Ceph Object Gateway Configuration
+# See http://ceph.com/docs/master/radosgw/ for details on installing this service.
+ceph-s3: &ceph-s3
+    <<: *common
+    storage: s3
+    s3_region: ~
+    s3_bucket: _env:AWS_BUCKET
+    s3_encrypt: _env:AWS_ENCRYPT:false
+    s3_secure: _env:AWS_SECURE:false
+    storage_path: _env:STORAGE_PATH:/registry
+    s3_access_key: _env:AWS_KEY
+    s3_secret_key: _env:AWS_SECRET
+    boto_bucket: _env:AWS_BUCKET
+    boto_host: _env:AWS_HOST
+    boto_port: _env:AWS_PORT
+    boto_debug: _env:AWS_DEBUG:0
+    boto_calling_format: _env:AWS_CALLING_FORMAT
+
+# Google Cloud Storage Configuration
+# See:
+# https://developers.google.com/storage/docs/reference/v1/getting-startedv1#keys
+# for details on access and secret keys.
+gcs:
+    <<: *common
+    storage: gcs
+    boto_bucket: _env:GCS_BUCKET
+    storage_path: _env:STORAGE_PATH:/registry
+    gs_secure: _env:GCS_SECURE:true
+    gs_access_key: _env:GCS_KEY
+    gs_secret_key: _env:GCS_SECRET
+    # OAuth 2.0 authentication with the storage.
+    # oauth2 can be set to true or false. If it is set to true, gs_access_key,
+    # gs_secret_key and gs_secure are not needed.
+    # Client ID and Client Secret must be set into OAUTH2_CLIENT_ID and
+    # OAUTH2_CLIENT_SECRET environment variables.
+    # See: https://developers.google.com/accounts/docs/OAuth2.
+    oauth2: _env:GCS_OAUTH2:false
+
+# This flavor is for storing images in Openstack Swift
+swift: &swift
+    <<: *common
+    storage: swift
+    storage_path: _env:STORAGE_PATH:/registry
+    # keystone authorization
+    swift_authurl: _env:OS_AUTH_URL
+    swift_container: _env:OS_CONTAINER
+    swift_user: _env:OS_USERNAME
+    swift_password: _env:OS_PASSWORD
+    swift_tenant_name: _env:OS_TENANT_NAME
+    swift_region_name: _env:OS_REGION_NAME
+
+# This flavor stores the images in Glance (to integrate with openstack)
+# See also: https://github.com/docker/openstack-docker
+glance: &glance
+    <<: *common
+    storage: glance
+    storage_alternate: _env:GLANCE_STORAGE_ALTERNATE:file
+    storage_path: _env:STORAGE_PATH:/tmp/registry
+
+openstack:
+    <<: *glance
+
+# This flavor stores the images in Glance (to integrate with openstack)
+# and tags in Swift.
+glance-swift: &glance-swift
+    <<: *swift
+    storage: glance
+    storage_alternate: swift
+
+openstack-swift:
+    <<: *glance-swift
+
+elliptics:
+    <<: *common
+    storage: elliptics
+    elliptics_nodes: _env:ELLIPTICS_NODES
+    elliptics_wait_timeout: _env:ELLIPTICS_WAIT_TIMEOUT:60
+    elliptics_check_timeout: _env:ELLIPTICS_CHECK_TIMEOUT:60
+    elliptics_io_thread_num: _env:ELLIPTICS_IO_THREAD_NUM:2
+    elliptics_net_thread_num: _env:ELLIPTICS_NET_THREAD_NUM:2
+    elliptics_nonblocking_io_thread_num: _env:ELLIPTICS_NONBLOCKING_IO_THREAD_NUM:2
+    elliptics_groups: _env:ELLIPTICS_GROUPS
+    elliptics_verbosity: _env:ELLIPTICS_VERBOSITY:4
+    elliptics_logfile: _env:ELLIPTICS_LOGFILE:/dev/stderr
+    elliptics_addr_family: _env:ELLIPTICS_ADDR_FAMILY:2
+
+# This flavor stores the images in Aliyun OSS
+# See:
+# https://i.aliyun.com/access_key/
+# for details on access and secret keys.
+oss: &oss
+    <<: *common
+    storage: oss
+    storage_path: _env:STORAGE_PATH:/registry/
+    oss_host: _env:OSS_HOST
+    oss_bucket: _env:OSS_BUCKET
+    oss_accessid: _env:OSS_KEY
+    oss_accesskey: _env:OSS_SECRET
+
+
+
+# This is the default configuration when no flavor is specified
+dev: &dev
+    <<: *local
+    loglevel: _env:LOGLEVEL:debug
+    debug: _env:DEBUG:true
+
+# This flavor is used by unit tests
+test:
+    <<: *dev
+    index_endpoint: https://registry-stage.hub.docker.com
+    standalone: true
+    storage_path: _env:STORAGE_PATH:./tmp/test
+
+# To specify another flavor, set the environment variable SETTINGS_FLAVOR
+# $ export SETTINGS_FLAVOR=prod
+prod:
+    <<: *s3
+    storage_path: _env:STORAGE_PATH:/prod
+


### PR DESCRIPTION
V1 registry fails often on startup due to a race caused by the search backend.
Use a configuration which does not set a search backend since it is not tested.

During my testing this seems to have done the trick, no more failures on v1 startup.

Ping @dmp42 