### PR TITLE
Add environments back to base image

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -584,6 +584,10 @@ func BuildBaseImage(client DockerClient, conf BaseImageConfiguration, c CacheCon
 
 	fmt.Fprintln(df, "COPY ./images /images")
 
+	for _, e := range envs {
+		fmt.Fprintf(df, "ENV %s\n", e)
+	}
+
 	// Call build
 	builder, err := client.NewBuilder(td, "", "")
 	if err != nil {


### PR DESCRIPTION
Environment version mistakenly got removed with the docker removal, this is needed for version checking.