### PR TITLE
Add support for a matrix of custom images

### DIFF
--- a/runner/matrix.go
+++ b/runner/matrix.go
@@ -1,0 +1,52 @@
+package runner
+
+func expandCustomImageMatrix(images []CustomImage) [][]CustomImage {
+	imageMatrix := make([][]CustomImage, 0, len(images))
+	for _, img := range images {
+		if len(imageMatrix) == 0 {
+			imageMatrix = append(imageMatrix, []CustomImage{img})
+			continue
+		}
+		var exists bool
+		for i, target := range imageMatrix[0] {
+			// if column already exists, duplicate all rows with same CustomImage
+			if target.Target.String() == img.Target.String() {
+				exists = true
+				matrixEnd := len(imageMatrix)
+				for j := 0; j < matrixEnd; j++ {
+					if j > 0 && !equalCustomImage(imageMatrix[0][i], imageMatrix[j][i]) {
+						continue
+					}
+					// Is same CustomImage
+					imagesCopy := append([]CustomImage{}, imageMatrix[j]...)
+					imagesCopy[i] = img
+					imageMatrix = append(imageMatrix, imagesCopy)
+				}
+				break
+			}
+		}
+
+		// If image did not exist, add column by adding to each row
+		if !exists {
+			for i := range imageMatrix {
+				imageMatrix[i] = append(imageMatrix[i], img)
+			}
+		}
+	}
+
+	return imageMatrix
+}
+
+func equalCustomImage(i1, i2 CustomImage) bool {
+	if i1.Source != i2.Source {
+		return false
+	}
+	if i1.Target.String() != i2.Target.String() {
+		return false
+	}
+	if i1.Version != i2.Version {
+		return false
+	}
+
+	return true
+}

--- a/runner/matrix_test.go
+++ b/runner/matrix_test.go
@@ -1,0 +1,63 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/docker/distribution/reference"
+)
+
+func mustImage(source, target, version string) CustomImage {
+	ref, err := reference.Parse(target)
+	if err != nil {
+		panic(err)
+	}
+	namedTagged, ok := ref.(reference.NamedTagged)
+	if !ok {
+		panic("must provided named tagged for image target")
+	}
+
+	return CustomImage{
+		Source:  source,
+		Target:  namedTagged,
+		Version: version,
+	}
+}
+
+func TestImageMatrixExpansion(t *testing.T) {
+	startImages := []CustomImage{
+		mustImage("golem-image1:v1.10.1", "image1:latest", "1.10.1"),
+		mustImage("golem-image2:v1.10.1", "image2:latest", "1.10.1"),
+		mustImage("golem-image3:v1.10.1", "image3:latest", "1.10.1"),
+		mustImage("golem-image2:v1.10.2", "image2:latest", "1.10.2"),
+		mustImage("golem-image2:v1.10.3", "image2:latest", "1.10.3"),
+		mustImage("golem-image1:v1.11.1", "image1:latest", "1.11.1"),
+		mustImage("golem-image4:v1.10.1", "image4:latest", "1.10.1"),
+	}
+	matrix := [][]CustomImage{
+		{startImages[0], startImages[1], startImages[2], startImages[6]},
+		{startImages[0], startImages[3], startImages[2], startImages[6]},
+		{startImages[0], startImages[4], startImages[2], startImages[6]},
+		{startImages[5], startImages[1], startImages[2], startImages[6]},
+		{startImages[5], startImages[3], startImages[2], startImages[6]},
+		{startImages[5], startImages[4], startImages[2], startImages[6]},
+	}
+
+	expanded := expandCustomImageMatrix(startImages)
+
+	if len(expanded) != len(matrix) {
+		t.Log("Expanded:", expanded)
+		t.Fatalf("Unexpected matrix size %d, expected %d", len(expanded), len(matrix))
+	}
+
+	for i := range matrix {
+		if len(expanded[i]) != len(matrix[i]) {
+			t.Fatalf("Unexpected array size %d, expected %d", len(expanded[i]), len(matrix[i]))
+		}
+
+		for j := range matrix[i] {
+			if !equalCustomImage(expanded[i][j], matrix[i][j]) {
+				t.Fatalf("Unexpected custom image %v, expected %v", expanded[i][j], matrix[i][j])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Each permutation of custom images must be tested when providing multiple versions for a given target.

Resolves #30 