### PR TITLE
Add support for tests with no custom images

### DIFF
--- a/examples/hello-world/golem.conf
+++ b/examples/hello-world/golem.conf
@@ -1,0 +1,7 @@
+[[suite]]
+  dind=true
+  images=[ "hello-world:latest" ]
+
+  [[suite.testrunner]]
+    command="docker run hello-world"
+


### PR DESCRIPTION
Without custom images a test instance was not being created, requiring at least one custom image.
This changes suite creation to not require custom images to create an instance.
Added hello-world example which is simplest runnable configuration using a docker image.
Fixed but where default targets not being added when no custom image flags sent.