### PR TITLE
Use awk instead of grep to check file

### DIFF
--- a/examples/registry/helpers.bash
+++ b/examples/registry/helpers.bash
@@ -68,7 +68,8 @@ function login_oauth() {
 
 	tmpFile=$(mktemp)
 	get_file_t /root/.docker/config.json $tmpFile
-	grep -Pz "\"$1\": \\{[[:space:]]+\"auth\": \"[[:alnum:]]+\",[[:space:]]+\"identitytoken\"" $tmpFile
+	run awk -v RS="" "/\"$1\": \\{[[:space:]]+\"auth\": \"[[:alnum:]]+\",[[:space:]]+\"identitytoken\"/ {exit 3}" $tmpFile
+	[ "$status" -eq 3 ]
 }
 
 function parse_version() {


### PR DESCRIPTION
In alpine awk has better support for multiline matching than grep.
